### PR TITLE
Correct 2016-07-25 reference to RcppCCTZ

### DIFF
--- a/_posts/2016-7-25-issue-9.md
+++ b/_posts/2016-7-25-issue-9.md
@@ -117,7 +117,7 @@ Hello and welcome to the new issue of **R Weekly**!
 
 ## New Releases
 
-+ [RcppCCTZ 0.0.5](http://dirk.eddelbuettel.com/blog/2016/07/21/#rcppcctz_0.0.5) - CCTZ is a time series library.
++ [RcppCCTZ 0.0.5](http://dirk.eddelbuettel.com/blog/2016/07/21/#rcppcctz_0.0.5) - CCTZ is a time zone library.
 
 + [Rcpp 0.12.6](http://dirk.eddelbuettel.com/blog/2016/07/19/#rcpp_0.12.6) - 703 packages on CRAN now depend on Rcpp.
 


### PR DESCRIPTION
### Changes and Descriptions

Changed / corrected comment behind link to [RcppCCTZ](https://cloud.r-project.org/web/packages/RcppCCTZ/index.html) release:  It is time _zone_ not time _series_
### Related Issues

Still don't know whether to consistently write _time zone and time series_ or _timezones and timeseries_.  I think the former is more common.
