### PR TITLE
Change link to new R graph gallery

### DIFF
--- a/_posts/2016-10-24-22.md
+++ b/_posts/2016-10-24-22.md
@@ -26,7 +26,7 @@ Hello and welcome to the new issue of **R Weekly**!
 
 + [Combing R and Java](https://datadidit.com/2016/10/15/combing-r-and-java/)
 
-+ [The new R Graph Gallery](https://www.r-bloggers.com/author/david-smith/)
++ [The new R Graph Gallery](http://www.r-graph-gallery.com/)
 
 + [Why I would rather use ReporteRs than RMarkdown](http://www.mango-solutions.com/wp/2016/10/why-i-would-rather-use-reporters-than-rmarkdown/)
 


### PR DESCRIPTION
The previous link was to David Smith's author page on R-bloggers. If you wanted to link to David's post about the graph gallery it is at https://www.r-bloggers.com/the-new-r-graph-gallery/, but probably just link directly to the site instead.
