### PR TITLE
one char typo fix to update packages

### DIFF
--- a/_posts/2016-11-14-25.md
+++ b/_posts/2016-11-14-25.md
@@ -176,7 +176,7 @@ Your browser does not support the video tag.
 
 + [rms 5.0-0](https://www.r-bloggers.com/major-update-to-rms-package-5-0-0/) - Regression Modeling Strategies.
 
-+ [anytime 0.1.0](http://dirk.eddelbuettel.com/blog/2016/11/07#anytime_0.1.0) - nytime aims to convert anything in integer, numeric, character, factor, ordered, ... format to POSIXct (or Date) objects.
++ [anytime 0.1.0](http://dirk.eddelbuettel.com/blog/2016/11/07#anytime_0.1.0) - anytime aims to convert anything in integer, numeric, character, factor, ordered, ... format to POSIXct (or Date) objects.
 
 + [gettz 0.0.3](http://dirk.eddelbuettel.com/blog/2016/11/07#gettz_0.0.3) - gettz provides a possible fallback in situations where Sys.timezone() fails to determine the system timezone.
 


### PR DESCRIPTION
### Changes and Descriptions

`anytime` was accidentally typed without its leading `a`

### Related Issues

`pkgKitten` was updated today; I tweeted and got a lot of likes + retweets.  May still fit, else it is next week.
