### PR TITLE
Remove duplicate link to nanotime package

### DIFF
--- a/_posts/2016-12-19-30.md
+++ b/_posts/2016-12-19-30.md
@@ -130,8 +130,6 @@ Hello and welcome to the new issue of **R Weekly**!
 
 + [jshinyserver](https://github.com/statsplot/jshinyserver) - jShiny Server is an alternative Shiny server.
 
-+ [nanotime](http://dirk.eddelbuettel.com/blog/2016/12/16#nanotime_0.0.1) - New package for Nanosecond Resolution Time for R.
-
 ### New Releases
 
 + [revealjs 0.8](https://github.com/rstudio/revealjs) - R Markdown Format for reveal.js Presentations


### PR DESCRIPTION
nanotime appears twice in the list of new packages
