### PR TITLE
deleted 2 links in the 'R in organization' section

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -76,11 +76,7 @@ Hello and welcome to the new issue of **R Weekly**!
 
 + [R for Enterprise: How to Scale Your Analytics Using R](https://www.rstudio.com/rviews/2016/12/21/r-for-enterprise-how-to-scale-your-analytics-using-r/)
 
-+ [Get Ready for RStudio::Conf](https://www.rstudio.com/rviews/2016/12/23/get-ready-for-rstudioconf/)
-
 + [Take a Test Drive of the Linux Data Science Virtual Machine](http://blog.revolutionanalytics.com/2016/12/dsvm-test-drive.html)
-
-+ [useR! 2017 website is online](https://www.r-bloggers.com/user-2017-website-is-online/)
 
 + [#Rstatsgoes10k – eoda is hosting a contest in celebration of R](https://blog.eoda.de/2016/12/21/rstatsgoes10k-eoda-is-hosting-a-contest-in-celebration-of-r/)
 


### PR DESCRIPTION
Since we have a comprehensive list of conferences in 2017 in the 'Resources' as well as we have mentioned some of them in the 'upcoming events'. I feel we don't have to repeatedly mention the conferences again here in 'R in organization'.

It will look redundant and make readers feel that we don't have anything else to post. or just to burden our readers by reading the repetitive posts.

### Changes and Descriptions

1. some text 
1. some text

### Related Issues

