### PR TITLE
Added link to the new pmatch package

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -54,6 +54,8 @@ Release Date: 2018-2-5
 
 **GitHub only**
 
++ <img class='emoji' src="https://link.rweekly.org/g" width='20' /> [pmatch](https://github.com/mailund/pmatch) - Haskell- and ML-like pattern matching for R
+
 + <img class='emoji' src="https://link.rweekly.org/g" width='20' /> [geniusR](https://github.com/josiahparry/geniusr) - Easily access song lyrics from Genius
 
 ### Package Releases


### PR DESCRIPTION
I added a link to draft.md to my new package, `pmatch`, available on GitHub. The package implements a domain-specific language for defining types and pattern matching on them. For example, you can create a linked list like this:

``` r
linked_list := NIL | CONS(car, cdr : linked_list)
```

This will define a constant, `NIL`, and a function, `CONS`, that can be used to create lists.

``` r
lst <- CONS(1, CONS(2, CONS(3, NIL)))
```

Using the `cases` function, we can then pattern match on the constructors `NIL` and `CONS` as shown in these examples:

``` r
list_length <- function(lst, acc = 0) {
  force(acc)
  cases(lst,
        NIL -> acc,
        CONS(car, cdr) -> list_length(cdr, acc + 1))
}

list_length(lst)
#> [1] 3

reverse_list <- function(lst, acc = NIL) {
  force(acc)
  cases(lst,
        NIL -> acc,
        CONS(car, cdr) -> reverse_list(cdr, CONS(car, acc)))
}

reverse_list(lst)
#> CONS(car = 3, cdr = CONS(car = 2, cdr = CONS(car = 1, cdr = NIL)))
```