### PR TITLE
Add blog post about Markov chain

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -41,7 +41,7 @@ Release Date: 2018-07-09
 
 ### R in the Real World
 
-
++ [Markov-chaining my PhD thesis](https://www.rostrum.blog/2018/06/30/markov-chain-phd/) - Build your own thesis with a Markov chain that generates text snippets of jargon about rotting leaves
 
 
 ###  R in Academia


### PR DESCRIPTION
Add '[Markov-chaining my PhD thesis](https://www.rostrum.blog/2018/06/30/markov-chain-phd/)' blog post to the 'R in the Real World' section [as per @maelle's suggestion](https://twitter.com/ma_salmon/status/1013297369696305152).