### PR TITLE
CRAN update: future, future.apply + talk

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -43,8 +43,6 @@ Release Date: 2019-00-00
 
 **CRAN**
 
-- [future.apply 1.2.0](https://cran.r-project.org/package=future.apply) - Apply Function to Elements in Parallel using Futures. Now with `future_by()`.
-
 
 **BioC**
 
@@ -56,6 +54,9 @@ Release Date: 2019-00-00
 
 ### Updated Packages
 
+- [future 1.12.0](https://cran.r-project.org/package=future) - Unified Parallel and Distributed Processing in R for Everyone.
+
+- [future.apply 1.2.0](https://cran.r-project.org/package=future.apply) - Apply Function to Elements in Parallel using Futures. Now with `future_by()`.
 
 
 ###  Videos and Podcasts

--- a/draft.md
+++ b/draft.md
@@ -34,6 +34,7 @@ Release Date: 2019-00-00
 
 ###  Resources
 
+- Henrik Bengtsson's [SatRday Paris 2019 Slides on Futures](https://www.jottr.org/2019/03/07/future-satrdayparis2019-slides/)
 
 
 ###  New Packages
@@ -42,6 +43,7 @@ Release Date: 2019-00-00
 
 **CRAN**
 
+- [future.apply 1.2.0](https://cran.r-project.org/package=future.apply) - Apply Function to Elements in Parallel using Futures. Now with `future_by()`.
 
 
 **BioC**


### PR DESCRIPTION
Slides: satRday Paris 2019 talk on Futures
CRAN update: future 1.12.0
CRAN update: future.apply 1.2.0
