### PR TITLE
Fix broken link in 2019-27

### DIFF
--- a/_posts/2019-07-08-2019-27.md
+++ b/_posts/2019-07-08-2019-27.md
@@ -39,7 +39,7 @@ image: https://rweekly.org/public/facebook.png
 
 + [Comrades Marathon (2019) Splits](https://datawookie.netlify.com/blog/2019/07/comrades-marathon-2019-splits/)
 
-+ [Exploring {gt} with useR! 2019 Schedule](citizen-statistician.org/2019/07/exploring-gt-with-user-2019-schedule/)
++ [Exploring {gt} with useR! 2019 Schedule](http://citizen-statistician.org/2019/07/exploring-gt-with-user-2019-schedule/)
 
 
 ###  R in Organizations


### PR DESCRIPTION
- Entry on 'Exploring {gt}...' had incorrect markdown format

Signed-off-by: Achintya Rao <achintya.rao@cern.ch>