### PR TITLE
Fix one broken link and switch two to HTTPS

### DIFF
--- a/_posts/2019-08-19-2019-33.md
+++ b/_posts/2019-08-19-2019-33.md
@@ -19,7 +19,7 @@ Release Date: 2019-08-19
 
 ### Insights
 
-+ [Can we use a neural network to generate R Shiny code?  Let's find out! ](https://https://appsilon.com/generate-shiny-code-with-rnn/)
++ [Can we use a neural network to generate R Shiny code?  Let's find out! ](https://appsilon.com/generate-shiny-code-with-rnn/)
 
 + [In search of the perfect partial dependence plot for Random Forests ](https://sethdobson.netlify.com/2019/08/08/in-search-of-the-perfect-partial-plot/)
 
@@ -33,7 +33,7 @@ Release Date: 2019-08-19
 
 + [Themes to Improve Your ggplot Figures](https://rfortherestofus.com/2019/08/themes-to-improve-your-ggplot-figures/)
 
-+ [Really Large Numbers in R](http://theautomatic.net/2019/08/16/really-large-numbers-in-r/)
++ [Really Large Numbers in R](https://theautomatic.net/2019/08/16/really-large-numbers-in-r/)
 
 ### R in the Real World
 
@@ -123,7 +123,7 @@ Release Date: 2019-08-19
 
 <img src = "https://github.com/rweekly/image/raw/master/2019/33/bob-ross.png" width = "600px">
 
-+ [Converting lines in an svg image to csv](http://shape-of-code.coding-guidelines.com/2019/08/16/converting-lines-in-an-svg-image-to-csv/)
++ [Converting lines in an svg image to csv](https://shape-of-code.coding-guidelines.com/2019/08/16/converting-lines-in-an-svg-image-to-csv/)
 
 + [Custom Discrete Color Scales for {ggplot2}](https://www.garrickadenbuie.com/blog/custom-discrete-color-scales-for-ggplot2/)
 


### PR DESCRIPTION
The link to the appsilon article was broken.

I checked the rest of the links and two of them with `HTTP` could in fact use `HTTPS`.

Signed-off-by: Achintya Rao <achintya.rao@cern.ch>