### PR TITLE
process_versions for CRAN links

### DIFF
--- a/scripts/process_versions.R
+++ b/scripts/process_versions.R
@@ -21,7 +21,7 @@ append_versions <- function(items, versions) {
   package_text <- items[package_names]
   package_text <- stringr::str_replace_all(package_text, "\\s\\s+", " ")
   new_package_text <- stringr::str_replace(package_text, "\\+ \\[(\\w+)", paste0("+ [{\\1} ", latest_version, ":"))
-  sort(new_package_text)
+  paste(sort(unique(new_package_text)), collapse = "\n")
 }
 
 ## this function is designed to work on 'clean' Rmd 
@@ -47,9 +47,9 @@ process_versions <- function(text = rstudioapi::getSourceEditorContext()$selecti
   message("DONE!")
   message("")
   message("New packages:")
-  print(append_versions(cran_packages, new))
+  cat(append_versions(cran_packages, new))
   message(" ")
   message("Updated packages:")
-  print(append_versions(cran_packages, updated))
+  cat(append_versions(cran_packages, updated))
   
 }

--- a/scripts/process_versions.R
+++ b/scripts/process_versions.R
@@ -1,0 +1,55 @@
+library(stringr)
+library(versions)
+library(rstudioapi)
+
+split_text_into_items <- function(text) {
+  stringr::str_split(as.character(text), "\\n")  
+}
+
+find_cran_links <- function(items) {
+  grep("cran.r-project.org/package=", unlist(items), fixed = TRUE, value = TRUE)
+}
+    
+extract_package_names <- function(item) {
+  x <- stringr::str_extract(item, "(?<=cran.r-project.org/package=)[^)]*")
+  setNames(item, x)
+}
+
+append_versions <- function(items, versions) {
+  package_names <- names(versions)
+  latest_version <- sapply(versions, function(x) x$version[[1]])
+  package_text <- items[package_names]
+  package_text <- stringr::str_replace_all(package_text, "\\s\\s+", " ")
+  new_package_text <- stringr::str_replace(package_text, "\\+ \\[(\\w+)", paste0("+ [{\\1} ", latest_version, ":"))
+  sort(new_package_text)
+}
+
+## this function is designed to work on 'clean' Rmd 
+## links and will extract the canonical CRAN links.
+## simply highlight your items in the Rmd and use `process_versions()` in 
+## the console. This will return a set of updated items for new and updated 
+## CRAN packages
+process_versions <- function(text = rstudioapi::getSourceEditorContext()$selection[[1]]$text) {
+  
+  if (!requireNamespace("versions")) {
+    stop("Please install the {versions} package")
+  }
+ 
+  items <- split_text_into_items(text)
+  cran_items <- find_cran_links(items)
+  cran_packages <- extract_package_name(cran_items)
+  message("Identifying versions... this make take a while...")
+  versions <- versions::available.versions(names(cran_packages))
+  is.new <- lapply(versions, nrow) == 1L
+  new <- versions[is.new]
+  updated <- versions[!is.new]
+  
+  message("DONE!")
+  message("")
+  message("New packages:")
+  print(append_versions(cran_packages, new))
+  message(" ")
+  message("Updated packages:")
+  print(append_versions(cran_packages, updated))
+  
+}


### PR DESCRIPTION
One of the parts of editing I dislike it trying to figure out which packages are new vs updated... so I scripted a solution.

Given a set of 'clean' Rmd links, e.g.

```
+ [Poisson point processes, mass shootings and clumping by @ellis2013nz](http://freerangestats.info/blog/2019/09/07/mass-shootings-oz)
+ [igate   Guided Analytics for Testing Manufacturing Parameters](https://cran.r-project.org/package=igate)
+ [fastcmprsk   Fine-Gray Regression via Forward-Backward Scan](https://cran.r-project.org/package=fastcmprsk)
+ [factorial2x2   Design and Analysis of 2x2 Factorial Trial](https://cran.r-project.org/package=factorial2x2)
+ [rawr   Retrieve Raw R Code from Popular Tutorials and Websites](https://cran.r-project.org/package=rawr)
+ [RPEGLMEN   Gamma and Exponential Generalized Linear Models with Elastic NetPenalty](https://cran.r-project.org/package=RPEGLMEN)
+ [pinp 0.0.8: Bugfix](http://dirk.eddelbuettel.com/blog/2019/09/08#pinp_0.0.8)
```

this script enables the issue editor to highlight these links (which contain a mixture of blog posts and CRAN links) and sort them into 'new' and 'updated' CRAN package categories, via `process_versions` in an RStudio console. Result:

```
Identifying versions... this make take a while...
DONE!

New packages:
+ [{factorial2x2} 0.1.0: Design and Analysis of 2x2 Factorial Trial](https://cran.r-project.org/package=factorial2x2)
+ [{rawr} 0.1.0: Retrieve Raw R Code from Popular Tutorials and Websites](https://cran.r-project.org/package=rawr)
+ [{RPEGLMEN} 1.0: Gamma and Exponential Generalized Linear Models with Elastic NetPenalty](https://cran.r-project.org/package=RPEGLMEN) 
Updated packages:
+ [{fastcmprsk} 1.1.1: Fine-Gray Regression via Forward-Backward Scan](https://cran.r-project.org/package=fastcmprsk)
+ [{igate} 0.3.3: Guided Analytics for Testing Manufacturing Parameters](https://cran.r-project.org/package=igate)
```

Review and suggestions encouraged.