### PR TITLE
Add satRday-neuchatel

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -175,6 +175,8 @@ Events in 3 Months:
 
 + [This week's local R-User and applied stats events](https://community.rstudio.com/c/irl)
 
++ [satRday Neuchâtel 2020](https://neuchatel2020.satrdays.org/)
+
 More past events at [R conferences & meetups](https://conf.rweekly.org).
 
 


### PR DESCRIPTION
Dear rweekly maintainers,

We would like to inform the R community about the first satRday in Switzerland which would take place in Neuchâtel on March 14th.

Best regards

Elise Dupuis