### PR TITLE
Add styler blog post

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -65,7 +65,7 @@ Release Date: 2020-03-23
 
 ###  Tutorials
 
-
+[styler 1.3.0: Faster styling and ignore some lines](https://lorenzwalthert.netlify.com/post/styler-1-3-0/)
 
 <!--<div class="post-more-begin></div><div class="post-more-end"></div>-->
 


### PR DESCRIPTION
I put it under tutorials because in your contributing guide lines, it says only packages newer than 2 weeks or something can go under packages (and styler 1.3.2 landed on CRAN before). Happy to have it moved to the package section.