### PR TITLE
Add long blog post on R programming in the Windows Subsystem for Linux.

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -31,6 +31,8 @@ Release Date: 2020-04-13
 
 
 
++ [R programming in the Windows Subsystem for Linux](https://blog.jdblischak.com/posts/wsl-r/) - A comprehensive guide to setup an R development environment for Ubuntu running in the Windows Subsystem for Linux (WSL)
+
 ###  New Packages
 
 <p class="added-hostname"><a href="https://rweekly.org/live" target="_blank" class="externalLink">📦 <i>Go Live for More New Pkgs</i> 📦</a></p>


### PR DESCRIPTION
I wrote a [blog post](https://blog.jdblischak.com/posts/wsl-r/) on setting up the Windows Subsystem for Linux for R programming. It's pretty long, so I added it to the resources section based on the descriptions in `CONTRIBUTING.md`.  Please let me know if you'd prefer I move it to a different section such as tutorials.