### PR TITLE
fix for link formatting as table

### DIFF
--- a/_posts/2020-04-13-2020-15.md
+++ b/_posts/2020-04-13-2020-15.md
@@ -106,7 +106,7 @@ This week’s release was curated by [Ryo Nakagawara](https://twitter.com/R_by_R
 
 + [aRt programming: A series of videos describing how to create a new generative art system in R](https://www.youtube.com/playlist?list=PLRPB0ZzEYegNYW3ksiK3dvd6S4HMfKj1n)
 
-+ [Getting Started with R + StatsBomb | Analyzing Squad Rotation & Clustering Passes](https://www.youtube.com/watch?v=ilIIjqfstfQ)
++ [Getting Started with R + StatsBomb - Analyzing Squad Rotation & Clustering Passes](https://www.youtube.com/watch?v=ilIIjqfstfQ)
 
 ### R Internationally
 


### PR DESCRIPTION
vertical bar '|' in video title is invoking table formatting when rendered to
HTML. Replace with "-"?