### PR TITLE
Add terrainr to the list of GitHub packages

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -47,7 +47,7 @@ Release Date: 2020-10-19
 
 
 **GitHub or Bitbucket**
-
++ [{terrainr}: Retrieve Data from the 'USGS' National Map and Transform it for '3D' Landscape Visualizations](https://mikemahoney218.github.io/terrainr/)
 
 
 ### Updated Packages


### PR DESCRIPTION
Hi all! This is a PR to add terrainr to the list of github packages for week 42.

If you want, either of these images (of visualizations produced with the data from {terrainr} -- the viz is done in Unity, but data retrieval and formatting is handled by terrainr) could be listed alongside the package:

From the introductory vignette:
![image](https://user-images.githubusercontent.com/38229299/96279935-52e9b300-0fa5-11eb-8be2-b80201e1ed83.png)

Not yet included in documentation:
![Figure_1](https://user-images.githubusercontent.com/38229299/96280046-7b71ad00-0fa5-11eb-91b0-b93bdc98ebab.png)

Thank you!