### PR TITLE
List Package Peak-Engines

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -47,7 +47,7 @@ Release Date: 2020-00-00
 
 
 **GitHub or Bitbucket**
-
+[{Peak-Engines}](https://github.com/rnburn/peak-engines) 0.2.8: Efficiently tune hyperparameters for GLMs to optimize leave-one-out cross-validation.
 
 
 ### Updated Packages


### PR DESCRIPTION
I recently added support for R to my project [peak-engines](https://github.com/rnburn/peak-engines). It automatically tunes hyperparameters for ridge regression and logistic regression to optimize approximate leave-one-out cross-validation. 

The process is described in this [paper](https://arxiv.org/abs/2011.10218), and the project includes notebooks that demonstrate usage for [ridge regression](https://github.com/rnburn/peak-engines/blob/master/example/ridge_regression/longley.ipynb) and [logistic regression](https://github.com/rnburn/peak-engines/blob/master/example/logistic_regression/diabetes.ipynb).