### PR TITLE
Add terrainr to new CRAN packages

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -41,7 +41,7 @@ This week’s release was curated by [Ryo Nakagawara](), with help from the R We
 
 **CRAN**
 
-
++ [{terrainr} 0.3.1](https://cran.r-project.org/package=terrainr): Landscape Visualizations in R and 'Unity'
 
 **BioC**
 


### PR DESCRIPTION
Hi all!

This package adds [terrainr](https://cran.r-project.org/package=terrainr) to the new CRAN listings.

If you wanted, either of these images could make for good representations of what the package does:
![image](https://user-images.githubusercontent.com/38229299/109019521-13d01a80-7687-11eb-8e5c-2bace216b023.png)
![image](https://user-images.githubusercontent.com/38229299/109019563-1b8fbf00-7687-11eb-998e-8e25835f0c58.png)

Thank you!