### PR TITLE
Add SARS-CoV-2 shiny app

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -85,6 +85,8 @@ This week’s release was curated by [](), with help from the R Weekly team memb
 
 + [Running pace calculator in R Shiny](https://statsandr.com/blog/running-pace-calculator/)
 
++ [Exploring dynamics of different SARS-CoV-2 vaccine rollout strategies](https://grenfelllab.shinyapps.io/sarscov2vaccine/)
+
 
 ### R Internationally
 


### PR DESCRIPTION
Hi, I've added a link to a new shiny app simulating the effects of different SARS-CoV-2 vaccine rollout strategies. 

This is my first time contributing to rweekly so apologies if I've made any mistakes creating the request!