### PR TITLE
Add RCWG minutes for July

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -80,8 +80,9 @@ This week’s release was curated by [](), with help from the R Weekly team memb
 
 ###  R Project Updates
 
-Updates from [R Core](http://developer.r-project.org/blosxom.cgi/R-devel/NEWS):
+Updates from [R Core](http://developer.r-project.org/blosxom.cgi/R-devel/NEWS).
 
+Minutes from the [R Contribution Working Group July Meeting](https://github.com/forwards/rcontribution/blob/master/team_minutes/2021-07-23.md).
 
 ###  Upcoming Events in 3 Months
 


### PR DESCRIPTION
For greater visibility, we would like to add the minutes from R Contribution Working Group meetings (every 1-2 months) to R Weekly. Since this is a working group in collaboration with R Core, it seems appropriate for the R Project Updates section.