### PR TITLE
Add R-hub post that was not included

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -18,7 +18,7 @@ This week’s release was curated by [](), with help from the R Weekly team memb
 
 ### Insights
 
-
++ [Caching the results of functions of your R package](https://blog.r-hub.io/2021/07/30/cache/)
 
 ### R in the Real World
 


### PR DESCRIPTION
At least I did not see it in the issues after it was published? In any case thanks for your continuous work!

Cc @cderv

PS: I still have editing rights to this repo which should be removed.