### PR TITLE
Add updates from RCWG

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -82,6 +82,15 @@ This week’s release was curated by [](), with help from the R Weekly team memb
 
 Updates from [R Core](http://developer.r-project.org/blosxom.cgi/R-devel/NEWS):
 
+Update from the [R Contribution Working Group](https://forwards.github.io/rcontribution/working-group) (RCWG):
+
+* Saranjeet Kaur has been awarded a grant in the The Digital Infrastructure Incubator at Code for Science & Society (https://incubator.codeforscience.org/cohort). 
+  * Project will build off of the R Development Guide to foster a sustainable community around it, likely through monthly "collaboration campfires" to work through open issues and develop tutorials.
+* Still considering planning a bug barbecue, likely in spring or summer 2022, possibly coordinating with useR.
+* We are looking for a few volunteers to help administer the R-devel slack and to communicate updates from the group. Contact Heather Turner if interested.
+
+See the [minutes](https://github.com/forwards/rcontribution/blob/master/team_minutes/2021-12-10.md) for full details on these and other topics we discussed, and the [RCWG repo README](https://github.com/forwards/rcontribution) for information on how to get involved. Our next meeting will be Tuesday, January 18, 2022, 20:00-21:00 UTC.
+
 
 ###  Upcoming Events in 3 Months
 


### PR DESCRIPTION
Add updates from today's RCWG meeting. Note the link to the meeting minutes will work once [this PR](https://github.com/forwards/rcontribution/pull/25) is merged.