### PR TITLE
change mastodon account link in footer

### DIFF
--- a/_includes/footer.md
+++ b/_includes/footer.md
@@ -146,7 +146,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
 [R](https://www.r-project.org/) is a free software environment for statistical computing and graphics.
 
-R Weekly @ [Facebook](https://facebook.com/rweekly), [Twitter](https://twitter.com/rweekly_org), [Mastodon](https://mastodon.social/@rweekly)
+R Weekly @ [Facebook](https://facebook.com/rweekly), [Twitter](https://twitter.com/rweekly_org), [Mastodon](https://fosstodon.org/@rweekly)
 
 This website uses [cookies](/privacy).
 


### PR DESCRIPTION
This PR fixes the mastodon social account link in the footer of the site. Previously it pointed to <https://mastodon.social/@rweekly> and now it points to the proper account at <https://fosstodon.org/@rweekly>.