### PR TITLE
Added a link to a tutorial about drat

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -76,7 +76,7 @@ This week’s release was curated by [](), with help from the R Weekly team memb
 
 ###  Tutorials
 
-
++ [Distributing R packages with a drat repository hosted on AWS S3](https://tomsing1.github.io/blog/posts/drat/)
 
 <!--<div class="post-more-begin></div><div class="post-more-end"></div>-->
 


### PR DESCRIPTION
I proposed to add a link to [my tutorial](https://tomsing1.github.io/blog/posts/drat/) on "Distributing R packages with a drat repository hosted on AWS S3"

## Type of Content

Either 
- [x] Tutorials - R tutorials for how to use certain packages and tools (usually code is embedded)

### I'd like to propose an Image from my new content!

- [ ] Yes, I proposed an image and resized it
- [ ] Yes, I proposed an image but didn't resized it
- [x] No, I didn't propose an image

# Checklist:

- [x] My content is R-related 
- [x] All images suggested are re-sized before has been added to the PR
- [x] I've submitted my content between Monday-Friday to allow for it to be voted by R Weekly editors for highlights
