### PR TITLE
Adds sumsar.net R blog feed to rss_feeds.csv

### DIFF
--- a/rss_feeds.csv
+++ b/rss_feeds.csv
@@ -385,3 +385,5 @@
 "https://blog.r-project.org/index.xml",1,""
 "https://dieghernan.github.io/rweekly.xml",1,"https://twitter.com/dhernangomez"
 "https://tomsing1.github.io/blog/index.xml",1,"https://twitter.com/thomas_sandmann"
+"https://www.sumsar.net/tags/r/index.xml", 1, "https://twitter.com/rabaath"
+


### PR DESCRIPTION
This PR proposes to add blogposts tagged with `R` from my blog [sumsar.net](https://www.sumsar.net/tags/r/). I blog mostly about statistics and data science, and then mostly in R.

## Type of Content

- [x] Tutorials - R tutorials for how to use certain packages and tools (usually code is embedded)
- [x] Insights - Articles that talk about R and data science in general (usually no code embedded)
- [x] R in Real World - Posts that discuss analyses that use R to analyze real-world data sets
- [ ] R in Organization - R use cases/events that showcase how organizations are utilizing or integrating R
- [ ] R in Academia - R use cases that showcase how Academia is utilizing R
- [ ] International - Non-English R related content
- [ ] Videos and Podcasts - Videos and Podcasts about R
- [ ] Resources - long posts, websites, books, slides, list, cheat sheets, or other learning resources in general that are more officially aggregated as a guide material
- [ ] Jobs - R Jobs
- [ ] New Packages and Tools - New packages and tools that have been created or published in the past two weeks.
- [ ] Updated Packages - New releases of tools and packages for R
- [ ] Call for Participation - New R groups, communities or competitions here. 
- [ ] Upcoming Events - Interesting R-related events or call for Participation section.
- [ ] R Project Updates: it belongs here rather than the call for participation because it is about contribution to the R project itself and is a collaboration with R core.


# Checklist:

- [x] My content is R-related 
