### PR TITLE
Remove all traces of feed/mail links

### DIFF
--- a/_includes/footer.md
+++ b/_includes/footer.md
@@ -25,8 +25,6 @@ document.getElementById('search-form').addEventListener('submit', function(e){
 
 <p></p>
 
-Subscribe R Weekly with <a href="https://feedburner.google.com/fb/a/mailverify?uri=rweekly&amp;loc=en_US" target="_blank" onclick="_paq.push(['trackEvent', 'Mail', '1']);">Email</a>.
-
 Do you enjoy R Weekly?
 
 <div id="star-rating" class="rating" style="margin-bottom:10px;" >

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -22,7 +22,6 @@
           <a href="{{ site.baseurl }}/" title="Home" style="padding: 0 9px 0 0;font-weight: bold; opacity: 1;">RWeekly.org</a>
           <a href="https://rweekly.fireside.fm/" style="padding: 0 9px 0 0;color:#2a7ae2;">Podcast</a>
           <a href="/live" style = "padding: 0 9px 0 0;color:#2a7ae2;">Live</a>
-          <a href="https://feedburner.google.com/fb/a/mailverify?uri=rweekly&amp;loc=en_US" target="_blank" onclick="_paq.push(['trackEvent', 'Mail', '1']);" style = "padding: 0 9px 0 0;color:#2a7ae2;">Mail</a>
           <a href="/atom.xml" style = "padding: 0 9px 0 0;color:#2a7ae2;">Feed</a>
           <!-- <a href="https://conf.rweekly.org" style = "padding: 0 9px 0 0;">Conf</a> -->
           {% for page in site.pages_list %}

--- a/about.md
+++ b/about.md
@@ -11,8 +11,6 @@ R Weekly was founded on May 20, 2016. R is growing very quickly, and there are l
 
 This is a warm and welcoming place. The team welcomes everyone who wants to contribute to the R community.
 
-Mail R Weekly - mail at rweekly.org
-
 Team Members (alphabet order)
 
 [Batool Almarzouq](https://github.com/BatoolMM), [Colin Fay](https://github.com/ColinFay), [Eric Nantz](https://github.com/thercast), [Jon Calder](https://github.com/jonmcalder), [Jonathan Carroll](https://github.com/jonocarroll), [Kelly N. Bodwin](https://github.com/kbodwin), [Miles McBain](https://github.com/MilesMcBain), [Robert Hickman](https://github.com/RobWHickman), [Ryo Nakagawara](https://github.com/Ryo-N7), [Sam Parmar](https://github.com/parmsam), [Tony ElHabr](https://github.com/tonyelhabr), [Wolfram Qin](https://github.com/qinwf)

--- a/about.md
+++ b/about.md
@@ -11,6 +11,8 @@ R Weekly was founded on May 20, 2016. R is growing very quickly, and there are l
 
 This is a warm and welcoming place. The team welcomes everyone who wants to contribute to the R community.
 
+Mail R Weekly - mail at rweekly.org
+
 Team Members (alphabet order)
 
 [Batool Almarzouq](https://github.com/BatoolMM), [Colin Fay](https://github.com/ColinFay), [Eric Nantz](https://github.com/thercast), [Jon Calder](https://github.com/jonmcalder), [Jonathan Carroll](https://github.com/jonocarroll), [Kelly N. Bodwin](https://github.com/kbodwin), [Miles McBain](https://github.com/MilesMcBain), [Robert Hickman](https://github.com/RobWHickman), [Ryo Nakagawara](https://github.com/Ryo-N7), [Sam Parmar](https://github.com/parmsam), [Tony ElHabr](https://github.com/tonyelhabr), [Wolfram Qin](https://github.com/qinwf)

--- a/live.html
+++ b/live.html
@@ -137,8 +137,6 @@ title: Live Updates and Bloggers from Data Science Community
   <div id="latest-app" class="inner-app-hide">
 
     <p class="added-hostname">
-      <a href="https://feedburner.google.com/fb/a/mailverify?uri=rweekly-live&amp;loc=en_US" id="mail-status"
-        target="_blank" class="externalLink">
         <svg width="20" height="20" viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg"
           style="margin-right: 8px;height: 25px;width: 25px;padding-top: 5px;margin-bottom: -4;">
           <path style="fill:grey;"
@@ -244,7 +242,6 @@ title: Live Updates and Bloggers from Data Science Community
       _paq.push(['trackEvent', 'set-ds', 'true']);
       document.getElementById('ds-status').innerText = " yes ";
       document.getElementById('main-post').classList.remove('post-hide-ds');
-      document.getElementById('mail-status').href = "https://feedburner.google.com/fb/a/mailverify?uri=rweekly-live&amp;loc=en_US";
       document.getElementById('rss-status').href = "https://feeds.feedburner.com/rweekly-live";
     } else {
       try {
@@ -255,7 +252,6 @@ title: Live Updates and Bloggers from Data Science Community
       _paq.push(['trackEvent', 'set-ds', 'false']);
       document.getElementById('ds-status').innerText = " no ";
       document.getElementById('main-post').classList.add('post-hide-ds');
-      document.getElementById('mail-status').href = "https://feedburner.google.com/fb/a/mailverify?uri=rweeklylive&amp;loc=en_US";
       document.getElementById('rss-status').href = "https://feeds.feedburner.com/rweeklylive";
     }
   }
@@ -398,11 +394,9 @@ title: Live Updates and Bloggers from Data Science Community
     if (localStorage.getItem("feature-ds") === 'false') {
       document.getElementById('ds-status').innerText = " no ";
       document.getElementById('main-post').classList.add('post-hide-ds');
-      document.getElementById('mail-status').href = "https://feedburner.google.com/fb/a/mailverify?uri=rweeklylive&amp;loc=en_US";
     } else {
       document.getElementById('ds-status').innerText = " yes ";
       document.getElementById('main-post').classList.remove('post-hide-ds');
-      document.getElementById('mail-status').href = "https://feedburner.google.com/fb/a/mailverify?uri=rweekly-live&amp;loc=en_US";
     }
     // try{
     //     var xlanguage = window.navigator.userLanguage || window.navigator.language;


### PR DESCRIPTION
Since the broken feed URL has been brought up in multiple GH issues now and we don’t seem to be close to a solution, my suggestion is to remove the mail link at the top of the page, as well as in the “Subscribe R Weekly with Email” text in the newsletter footer.

Addresses #1315.