### PR TITLE
add Pandoc blog post

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -18,7 +18,7 @@ This week’s release was curated by [](), with help from the R Weekly team memb
 
 ### Insights
 
-
++ [Troubleshooting Pandoc Problems as an R User](https://ropensci.org/blog/2023/06/01/troubleshooting-pandoc-problems-as-an-r-user/) (also in [French](https://ropensci.org/fr/blog/2023/06/01/troubleshooting-pandoc-problems-as-an-r-user/))
 
 ### R in the Real World
 

--- a/draft.md
+++ b/draft.md
@@ -18,8 +18,6 @@ This week’s release was curated by [](), with help from the R Weekly team memb
 
 ### Insights
 
-+ [Troubleshooting Pandoc Problems as an R User](https://ropensci.org/blog/2023/06/01/troubleshooting-pandoc-problems-as-an-r-user/) (also in [French](https://ropensci.org/fr/blog/2023/06/01/troubleshooting-pandoc-problems-as-an-r-user/))
-
 ### R in the Real World
 
 
@@ -75,6 +73,8 @@ This week’s release was curated by [](), with help from the R Weekly team memb
 
 
 ###  Tutorials
+
++ [Troubleshooting Pandoc Problems as an R User](https://ropensci.org/blog/2023/06/01/troubleshooting-pandoc-problems-as-an-r-user/) (also in [French](https://ropensci.org/fr/blog/2023/06/01/troubleshooting-pandoc-problems-as-an-r-user/))
 
 
 


### PR DESCRIPTION
Related question: is ropensci.org RSS feed hooked into R Weekly and if not how can I help?

# Adding new content to R Weekly issue

a Pandoc blog post for R users, featuring the R package pandoc.

## Type of Content

**Please select to which section(s) your post belongs!**

<!--Please don't add anything to the Highlight section, R Weekly editors vote for the content of this section weekly--> 

- [x] Tutorials - R tutorials for how to use certain packages and tools (usually code is embedded)
- [ ] Insights - Articles that talk about R and data science in general (usually no code embedded)
- [ ] R in Real World - Posts that discuss analyses that use R to analyze real-world data sets
- [ ] R in Organization - R use cases/events that showcase how organizations are utilizing or integrating R
- [ ] R in Academia - R use cases that showcase how Academia is utilizing R
- [ ] International - Non-English R related content
- [ ] Videos and Podcasts - Videos and Podcasts about R
- [ ] Resources - long posts, websites, books, slides, list, cheat sheets, or other learning resources in general that are more officially aggregated as a guide material
- [ ] Jobs - R Jobs
- [ ] New Packages and Tools - New packages and tools that have been created or published in the past two weeks.
- [ ] Updated Packages - New releases of tools and packages for R
- [ ] Call for Participation - New R groups, communities or competitions here. 
- [ ] Upcoming Events - Interesting R-related events or call for Participation section.
- [ ] R Project Updates: it belongs here rather than the call for participation because it is about contribution to the R project itself and is a collaboration with R core.


# Checklist:

- [x] My content is R-related 
- [x] All images suggested are re-sized before has been added to the PR
- [x] I've submitted my content between Monday-Friday to allow for it to be voted by R Weekly editors for highlights
