### PR TITLE
Add my blog to feeds list and add a previous post to Tutorials section of draft

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -79,6 +79,8 @@ This week’s release was curated by [](), with help from the R Weekly team memb
 
 [I Made R Text For Me](https://brendenmsmith.com/posts/text%20in%20r/)
 
+[Creating a simple Automator app to launch a new instance of RStudio Desktop on macOS](https://remlapmot.github.io/post/2024/macos-rstudio-another/)
+
 <!--<div class="post-more-begin></div><div class="post-more-end"></div>-->
 
 ### R Project Updates

--- a/rss_feeds.csv
+++ b/rss_feeds.csv
@@ -410,3 +410,4 @@
 "https://pablobernabeu.github.io/categories/r/index.xml",1,""
 "https://albert-rapp.de/blog.xml",1,"https://twitter.com/rappa753"
 "https://ecogambler.netlify.app/blog/index.xml",1,"https://twitter.com/nj_clark"
+"https://remlapmot.github.io/tag/r/index.xml",1,""


### PR DESCRIPTION
# Adding new content to R Weekly issue

I would like to add the feed for my R blog, and one of my previous posts.

## Type of Content

**Please select to which section(s) your post belongs!**

<!--Please don't add anything to the Highlight section, R Weekly editors vote for the content of this section weekly--> 

- [x] Tutorials - R tutorials for how to use certain packages and tools (usually code is embedded)
- [ ] Insights - Articles that talk about R and data science in general (usually no code embedded)
- [ ] R in Real World - Posts that discuss analyses that use R to analyze real-world data sets
- [ ] R in Organization - R use cases/events that showcase how organizations are utilizing or integrating R
- [x] R in Academia - R use cases that showcase how Academia is utilizing R
- [ ] International - Non-English R related content
- [ ] Videos and Podcasts - Videos and Podcasts about R
- [ ] Resources - long posts, websites, books, slides, list, cheat sheets, or other learning resources in general that are more officially aggregated as a guide material
- [ ] Jobs - R Jobs
- [x] New Packages and Tools - New packages and tools that have been created or published in the past two weeks.
- [x] Updated Packages - New releases of tools and packages for R
- [ ] Call for Participation - New R groups, communities or competitions here. 
- [ ] Upcoming Events - Interesting R-related events or call for Participation section.
- [ ] R Project Updates: it belongs here rather than the call for participation because it is about contribution to the R project itself and is a collaboration with R core.


### I'd like to propose an Image from my new content!

<!--Although you are very welcome to suggest an image, please bear in mind that images are added and changed by the editor in charge of the issue so we can't guarantee that your image will be added--> 

Please feel free to suggest an image from your content to be added in the next issue. Any image added has to be re-sized to a max width 600px. This can be carried out using [rweekly.tools](https://github.com/rweekly/rweekly.tools) or any online tool.

- [ ] Yes, I proposed an image and resized it
- [ ] Yes, I proposed an image but didn't resized it
- [x] No, I didn't propose an image

# Checklist:

- [x] My content is R-related 
- [ ] All images suggested are re-sized before has been added to the PR
- [x] I've submitted my content between Monday-Friday to allow for it to be voted by R Weekly editors for highlights
