### PR TITLE
Jobs to Connect

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@ Please include a one-sentence summary of the new content you would like to be ad
 - [ ] International - Non-English R related content
 - [ ] Videos and Podcasts - Videos and Podcasts about R
 - [ ] Resources - long posts, websites, books, slides, list, cheat sheets, or other learning resources in general that are more officially aggregated as a guide material
-- [ ] Jobs - R Jobs
+- [ ] Connect - R Jobs and Communities
 - [ ] New Packages and Tools - New packages and tools that have been created or published in the past two weeks.
 - [ ] Updated Packages - New releases of tools and packages for R
 - [ ] Call for Participation - New R groups, communities or competitions here. 

--- a/draft.md
+++ b/draft.md
@@ -113,9 +113,9 @@ Events in 3 Months:
 ### Datasets
 
 
-### Jobs
+### Connect
 
-<i>💼 [Explore Jobs & Gigs Board on RStudio Community](https://community.rstudio.com/c/jobs/) 💼</i>
+<i>[Join the Data Science Learning Community](https://DSLC.io/)</i>
 
 ### rtistry
 

--- a/for-editor-only-draft.txt
+++ b/for-editor-only-draft.txt
@@ -102,9 +102,9 @@ Events in 3 Months:
 ### Datasets
 
 
-### Jobs
+### Connect
 
-<i>💼 [Explore Jobs & Gigs Board on RStudio Community](https://community.rstudio.com/c/jobs/) 💼</i>
+<i>[Join the Data Science Learning Community](https://DSLC.io/)</i>
 
 ### rtistry
 


### PR DESCRIPTION
The "Jobs & Gigs Board" isn't available on Posit Community. Since I don't have a specific place to send people for "Jobs" in particular, rather than leaving that section blank, I changed it to "Connect" and added DSLC.io (for job postings, learning, and more ). I updated the PR template to match. Does that sound ok?

# Adding new content to R Weekly issue

"Connect" section to replace and expand "Jobs" section.

## Type of Content

- [x] Jobs - R Jobs

### I'd like to propose an Image from my new content!

- [x] No, I didn't propose an image

# Checklist:

- [x] My content is R-related 
- [x] All images suggested are re-sized before has been added to the PR
- [x] I've submitted my content between Monday-Friday to allow for it to be voted by R Weekly editors for highlights
