### PR TITLE
Reapply Jobs to Connect transition.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,9 +52,9 @@ Videos and Podcasts about R.
 
 Long posts, websites, books, slides, list, cheat sheets, or other learning resources in general that are more officially aggregated as a guide material.
 
-## Jobs
+## Connect
 
-R Jobs.
+R Jobs and Communities.
 
 ## New Packages and Tools
 

--- a/draft.md
+++ b/draft.md
@@ -100,7 +100,7 @@ Events in 3 Months:
 + [Meta-Analysis in R workshop, July 11th 18:00-20:00 CEST](https://r-posts.com/11543-2/)
 
 
-### Jobs
+### Connect
 
-<i>💼 [Explore Jobs & Gigs Board on RStudio Community](https://community.rstudio.com/c/jobs/) 💼</i>
+<i>[Join the Data Science Learning Community](https://DSLC.io/)</i>
 


### PR DESCRIPTION
The Jobs link at RStudio Community is no longer active. Send people to DSLC instead. (Re-applies change that was applied in PR #1614 and later reverted, evidently accidentally)

## Type of Content

**Please select to which section(s) your post belongs!**

- [x] Connect - R Jobs and Communities
- [x] No, I didn't propose an image

# Checklist:

- [x] My content is R-related 
- [x] All images suggested are re-sized before has been added to the PR
- [x] I've submitted my content between Monday-Friday to allow for it to be voted by R Weekly editors for highlights
