### PR TITLE
Add R for the Rest of Us RSS feed

### DIFF
--- a/rss_feeds.csv
+++ b/rss_feeds.csv
@@ -425,3 +425,4 @@
 "https://rdatatable-community.github.io/The-Raft/index.xml", 1, ""
 "https://rworks.dev/index.xml", 1, ""
 "https://www.devxy.io/blog/categories/r/rss.xml", 1, ""
+"https://github.com/rfortherestofus/rweekly.org", 1, ""


### PR DESCRIPTION
Adding the RSS feed for the R for the Rest of Us blog. Thanks!