### PR TITLE
Add cynkra blog RSS feed

### DIFF
--- a/rss_feeds.csv
+++ b/rss_feeds.csv
@@ -427,3 +427,4 @@
 "https://www.devxy.io/blog/categories/r/rss.xml", 1, ""
 "https://github.com/rfortherestofus/rweekly.org", 1, ""
 "https://ctompkins.netlify.app/index.xml", 1, ""
+"https://blog.cynkra.com/index.xml", 1, ""


### PR DESCRIPTION
This is the blog feed of cynkra, that has much R content.

cc @divadnojnarg @christophsax @krlmlr