### PR TITLE
Edit R Consortium feed

### DIFF
--- a/rss_feeds.csv
+++ b/rss_feeds.csv
@@ -256,7 +256,7 @@
 "https://jcarroll.com.au/tags/rstats/index.xml",1,"@carroll_jono"
 "http://www.data-imaginist.com/feed.xml",1,"@thomasp85"
 "https://feeds.feedburner.com/rweekly/TBsy",1,"@rweekly_org"
-"https://www.r-consortium.org/feed",1,"@RConsortium"
+"https://r-consortium.org/blog/index.xml",1,"@RConsortium"
 "https://matloff.wordpress.com/feed/",1,""
 "http://mhoehle.github.io/blog/feed.xml",1,""
 "http://spatial.ly/feed/",1,""


### PR DESCRIPTION
Hello,

The R Consortium feed URL has changed since it moved to Quarto. I updated the CSV here.

Thanks for considering!