### PR TITLE
Update rss_feeds.csv

### DIFF
--- a/rss_feeds.csv
+++ b/rss_feeds.csv
@@ -388,7 +388,7 @@
 "https://medium.com/feed/@mcodrescu",1,"https://twitter.com/m_codrescu"
 "https://matthewrkaye.com/posts-r.xml",1,""
 "https://jakubnowosad.com/posts-rstats.xml",1,"https://twitter.com/jakub_nowosad"
-"https://nrennie.rbind.io/categories/r/index.xml",1,"https://twitter.com/nrennie35"
+"https://nrennie.rbind.io/blog/index-r.xml",1,""
 "https://www.codingthepast.com/feed_r_weekly.xml",1,"https://twitter.com/bruno_ponne"
 "https://www.carlislerainey.com/blog/index-r.xml", 1, "https://twitter.com/carlislerainey"
 "https://jonathankitt.netlify.app/blog.xml", 1, "https://twitter.com/KittJonathan"


### PR DESCRIPTION
I've updated my blog from Hugo to Quarto, so the RSS feed URL has changed, and the PR updates it to the new one