### PR TITLE
Improve messages when rejecting RSS feed posts

### DIFF
--- a/scripts/get_rss.R
+++ b/scripts/get_rss.R
@@ -107,7 +107,7 @@ get_rss_posts <- function(feeds = NULL, since_days_ago = 10) {
 
   message("✅ ", nrow(new_posts), " posts detected!")
   for (i in seq_len(nrow(new_posts))) {
-    message("   ⭐️ ", new_posts[[url_col]])
+    message("   ⭐️ ", new_posts[i, url_col])
   }
   message("\n")
 

--- a/scripts/get_rss.R
+++ b/scripts/get_rss.R
@@ -14,7 +14,7 @@ get_rss_posts <- function(feeds = NULL, since_days_ago = 10) {
 }
 
 .get_rss_post <- function(feed, since_days_ago = 10) {
-  message("parsing ", feed)
+  message("Checking: ", feed)
   all_posts <- try(tidyRSS::tidyfeed(feed), silent = TRUE)
   if (inherits(all_posts, "try-error")) {
     message("⛔️ ", "Feed reading failed for ", feed, "\n")
@@ -58,18 +58,20 @@ get_rss_posts <- function(feeds = NULL, since_days_ago = 10) {
 
   recent <- as.POSIXct(all_posts[[date_col]]) >=
     as.POSIXct(Sys.Date() - since_days_ago)
-  if (length(recent) < nrow(all_posts)) {
-    old_posts <- all_posts[!recent, , drop = FALSE]
+  if (sum(recent, na.rm = TRUE) < nrow(all_posts)) {
+    # old_posts <- all_posts[!recent, , drop = FALSE]
     message(
       "ℹ️ ",
-      "Not including the following posts older than ",
+      "Not including ",
+      nrow(all_posts) - sum(recent, na.rm = TRUE),
+      " posts older than ",
       since_days_ago,
-      " days"
+      " days\n"
     )
-    for (i in seq_len(nrow(old_posts))) {
-      message("❌ ", old_posts[i, url_col])
-    }
-    message("\n")
+    # for (i in seq_len(nrow(old_posts))) {
+    #   message("❌ ", old_posts[i, url_col])
+    # }
+    # message("\n")
   }
   new_posts <- all_posts[recent, , drop = FALSE]
   if (nrow(new_posts) == 0) return(invisible(NULL))

--- a/scripts/get_rss.R
+++ b/scripts/get_rss.R
@@ -17,8 +17,8 @@ get_rss_posts <- function(feeds = NULL, since_days_ago = 10) {
   message("parsing ", feed)
   all_posts <- try(tidyRSS::tidyfeed(feed), silent = TRUE)
   if (inherits(all_posts, "try-error")) {
-    warning("feed reading failed for ", feed)
-    return(NULL)
+    message("⛔️ ", "Feed reading failed for ", feed, "\n")
+    return(invisible(NULL))
   }
   title_col <- if (utils::hasName(all_posts, "item_title")) {
     "item_title"
@@ -42,11 +42,49 @@ get_rss_posts <- function(feeds = NULL, since_days_ago = 10) {
     if (all(is.na(all_posts$inferred_date))) return(NULL)
     "inferred_date"
   }
+  missing_date <- all_posts[is.na(all_posts[[date_col]]), , drop = FALSE]
+  if (nrow(missing_date)) {
+    message(
+      "ℹ️ ",
+      "Not including the following posts with unknown date"
+    )
+    for (i in seq_len(nrow(missing_date))) {
+      message("❌ ", missing_date[i, url_col])
+    }
+    message("\n")
+  }
+  all_posts <- all_posts[!is.na(all_posts[[date_col]]), , drop = FALSE]
+  if (nrow(all_posts) == 0) return(invisible(NULL))
+
   recent <- as.POSIXct(all_posts[[date_col]]) >=
     as.POSIXct(Sys.Date() - since_days_ago)
+  if (length(recent) < nrow(all_posts)) {
+    old_posts <- all_posts[!recent, , drop = FALSE]
+    message(
+      "ℹ️ ",
+      "Not including the following posts older than ",
+      since_days_ago,
+      " days"
+    )
+    for (i in seq_len(nrow(old_posts))) {
+      message("❌ ", old_posts[i, url_col])
+    }
+    message("\n")
+  }
   new_posts <- all_posts[recent, , drop = FALSE]
+  if (nrow(new_posts) == 0) return(invisible(NULL))
+
+  if (any(is.na(new_posts[[url_col]]))) {
+    message("ℹ️ ", "Not including the following posts missing a URL")
+    missing_urls <- new_posts[is.na(new_posts[[url_col]]), , drop = FALSE]
+    for (i in seq_len(nrow(missing_urls))) {
+      message("❌ ", missing_urls[i, title_col])
+    }
+    message("\n")
+  }
   new_posts <- new_posts[!is.na(new_posts[[url_col]]), , drop = FALSE]
-  if (nrow(new_posts) == 0) return(NULL)
+  if (nrow(new_posts) == 0) return(invisible(NULL))
+
   # process atom slugs
   if (
     all(startsWith(new_posts[[url_col]], "/")) &&
@@ -54,6 +92,24 @@ get_rss_posts <- function(feeds = NULL, since_days_ago = 10) {
   ) {
     new_posts[[url_col]] <- paste0(urltools::domain(feed), new_posts[[url_col]])
   }
-  message("*** ", nrow(new_posts), " posts detected!")
+
+  can_reach <- sapply(new_posts[[url_col]], RCurl::url.exists)
+  if (any(!can_reach)) {
+    unreach <- new_posts[!can_reach, , drop = FALSE]
+    message("ℹ️ ", "Not including the following unreachable URLs")
+    for (i in seq_len(nrow(unreach))) {
+      message("❌ ", new_posts[i, url_col])
+    }
+    message("\n")
+  }
+  new_posts <- new_posts[can_reach, , drop = FALSE]
+  if (nrow(new_posts) == 0) return(invisible(NULL))
+
+  message("✅ ", nrow(new_posts), " posts detected!")
+  for (i in seq_len(nrow(new_posts))) {
+    message("   ⭐️ ", new_posts[[url_col]])
+  }
+  message("\n")
+
   glue::glue("+ [{new_posts[[title_col]]}]({new_posts[[url_col]]})")
 }


### PR DESCRIPTION
Relevant to #1879 - we drop RSS results when they fail certain criteria (missing a date so we can't tell if it's recent; incorrectly configured URL; ...) but we can't see what caused that based on the output.

This PR adds some loggable messaging when we drop posts, makes it clearer when we can't read a feed, checks if we can actually reach each URL, and generally cleans up the feed fetching. The emojis help with doing a quick scan for errors.

The output format isn't changed, just what's logged to the console (and thus curatinator's logged output).

Please let me know if there's something else you think this should capture.

Example outputs:

```
parsing https://www.rstudio.com/blog/index.xml
GET request successful. Parsing...

⛔️ Feed reading failed for https://www.rstudio.com/blog/index.xml

parsing https://feeds.feedburner.com/AustinWehrwein
GET request successful. Parsing...

parsing http://dirk.eddelbuettel.com/blog/index.rss
GET request successful. Parsing...

✅ 2 posts detected!
   ⭐️ http://dirk.eddelbuettel.com/blog/2025/08/20#x13binary_1.1.61.1
   ⭐️ http://dirk.eddelbuettel.com/blog/2025/08/20#rcpparmadillo_14.6.3-1


parsing https://jonmcalder.github.io/feed.xml
⛔️ Feed reading failed for https://jonmcalder.github.io/feed.xml

parsing https://ellisp.github.io/feed.r.xml
GET request successful. Parsing...

✅ 1 posts detected!
   ⭐️ https://freerangestats.info/blog/2025/08/23/timeuse-technical

ℹ️ Not including the following posts with unknown date
❌ https://user2021.r-project.org/blog/1/01/01/liz-transcript/


ℹ️ Not including the following unreachable URLs
❌ https://b-rodrigues.github.io/posts/2025-08-22-pypan.html
```