### PR TITLE
Update title of "Jarl 0.4.0"

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -18,7 +18,7 @@ This week’s release was curated by [](), with help from the R Weekly team memb
 
 ### Insights
 
-+ [Jarl 0.4.0](https://www.etiennebacher.com/posts/2026-02-03-jarl-0.4.0/)
++ [Jarl 0.4.0: A fast R linter](https://www.etiennebacher.com/posts/2026-02-03-jarl-0.4.0/)
 
 + [secretbase: The hash package smaller than most hex stickers](https://shikokuchuo.net/posts/28-introducing-secretbase/)
 


### PR DESCRIPTION
Sorry for the second PR @rpodcast, just realized that the blog post title is clear enough on my blog because it comes after the announcement of Jarl, but it's not very clear on the RWeekly page.