### PR TITLE
Package dependency viz (Shiny)

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -247,8 +247,8 @@ Networks - [diffify](https://diffify.com/R/kindling)
 
 ### Shiny Apps
 
-
-
++ [Package Dependency vizualizer (on top of {PAK})](https://tinyurl.com/package-dependency-viz) <br>
+More details in [Bluesky](https://bsky.app/profile/yannco.bsky.social/post/3mecvgqapj22v)
 ### R Internationally
 
 


### PR DESCRIPTION
# Adding new content to R Weekly issue

Shiny app that creates a graph of package dependency based on `pak::pak_deps_explain` 
## Type of Content

**Please select to which section(s) your post belongs!**

- [x] Resources - long posts, websites, books, slides, list, cheat sheets, or other learning resources in general that are more officially aggregated as a guide material
- [x] New Packages and Tools - New packages and tools that have been created or published in the past two weeks.

### I'd like to propose an Image from my new content!
<img src="https://cdn.bsky.app/img/feed_thumbnail/plain/did:plc:mi3gralmrwkhkfqgsndglmzv/bafkreif6xebljzpzyepuokfyvpkwpgmepndlsswa3yeeofn4jpmfasuply@jpeg" style="max-width: 600px; width: 100%; height: auto;">


- [x] Yes, I proposed an image and resized it (via html)
