### PR TITLE
Add new CRAN packages: lineagefreq, survinger, clinicalfair, syntheticdata

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -47,6 +47,13 @@ This week’s release was curated by [](), with help from the R Weekly team memb
 
 **CRAN**
 
++ [{lineagefreq} 0.2.0](https://cran.r-project.org/package=lineagefreq): Lineage Frequency Dynamics from Genomic Surveillance Counts
+
++ [{survinger} 0.1.1](https://cran.r-project.org/package=survinger): Design-Adjusted Inference for Pathogen Lineage Surveillance
+
++ [{clinicalfair} 0.1.0](https://cran.r-project.org/package=clinicalfair): Algorithmic Fairness Assessment for Clinical Prediction Models
+
++ [{syntheticdata} 0.1.0](https://cran.r-project.org/package=syntheticdata): Synthetic Clinical Data Generation and Privacy-Preserving Validation
 
 **Bioconductor**
 


### PR DESCRIPTION
## New Packages and Tools

Adding four new CRAN packages to this week's issue:

- **lineagefreq** — Pathogen variant frequency dynamics and growth advantage estimation
- **survinger** — Design-adjusted prevalence estimation for genomic surveillance
- **clinicalfair** — Fairness auditing for clinical prediction models
- **syntheticdata** — Synthetic clinical data generation with privacy assessment

Related issue: Closes #2004

Submitted by: Cuiwei Gao (GitHub: @CuiweiG)