### PR TITLE
Add tutorial: logrittr for verbose pipe logging

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -34,6 +34,7 @@ This week’s release was curated by [](), with help from the R Weekly team memb
 
 ### Tutorials
 
++ [logrittr: A Verbose Pipe Operator for Logging dplyr Pipelines](https://guillaumepressiat.github.io/blog/2026/04/logrittr)
 
 ### Resources
 


### PR DESCRIPTION
Adding a tutorial post about logrittr, a verbose pipe operator that adds logging to dplyr pipelines for debugging.

- Blog post: https://guillaumepressiat.github.io/blog/2026/04/logrittr
- Author: Guillaume Pressiat
- Published: 2026-04-15

Submitted by: @CuiweiG