### PR TITLE
Add tutorial: Forecasting SARS-CoV-2 variant dominance

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -34,6 +34,8 @@ This week’s release was curated by [](), with help from the R Weekly team memb
 
 ### Tutorials
 
++ [Forecasting SARS-CoV-2 Variant Dominance: A Multi-Engine Approach](https://cuiweig.github.io/portfolio/01-variant-forecasting/)
+
 
 ### Resources
 


### PR DESCRIPTION
Adding a case study tutorial demonstrating multi-engine variant frequency modelling and rolling-origin backtesting.

- Published on my analysis portfolio: https://cuiweig.github.io/portfolio/01-variant-forecasting/
- Built with `lineagefreq` (CRAN): https://cran.r-project.org/package=lineagefreq
- Uses real CDC SARS-CoV-2 JN.1 surveillance data (public domain)
- Compares `mlr` and `piantham` engines and includes rolling-origin backtesting
- Ends with a decision-relevant answer: when does the JN.1 clade cross the 80 % dominance threshold?

Submitted by: Cuiwei Gao (@CuiweiG)