### PR TITLE
Add tutorial: Post-hoc fairness audit walkthrough (COMPAS case)

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -34,6 +34,8 @@ This week’s release was curated by [](), with help from the R Weekly team memb
 
 ### Tutorials
 
++ [Post-hoc Fairness Audit of a Deployed Risk Score (COMPAS Case)](https://cuiweig.github.io/portfolio/02-fair-clinical-prediction/)
+
 
 ### Resources
 


### PR DESCRIPTION
Adding a case study tutorial demonstrating post-hoc algorithmic fairness auditing of an already-deployed risk score — no model retraining required.

- Published on my analysis portfolio: https://cuiweig.github.io/portfolio/02-fair-clinical-prediction/
- Built with `clinicalfair` (CRAN): https://cran.r-project.org/package=clinicalfair
- Uses the COMPAS dataset — the canonical algorithmic fairness case from the ProPublica (2016) investigation
- Walks through `fairness_metrics`, four-fifths rule screening, ROC and calibration by group, and threshold optimisation for equalised odds / demographic parity
- Frames the Northpointe–ProPublica debate as the impossibility result from Chouldechova (2017) / Kleinberg et al. (2017)

Relevant to R users building or auditing clinical and public-sector prediction models under FDA / EEOC / GDPR expectations.

Submitted by: Cuiwei Gao (@CuiweiG)