### PR TITLE
Add Rverse Analytics blog RSS feed

### DIFF
--- a/rss_feeds.csv
+++ b/rss_feeds.csv
@@ -458,3 +458,4 @@
 "https://ctompkins.netlify.app/index.xml", 1, ""
 "https://github.com/BenWiseman/roperators/releases.atom",1,""
 "https://bastianolea.rbind.io/blog/index.xml",1,""
+"https://rverseanalytics.com/blog.xml",1,""


### PR DESCRIPTION
This adds the RSS feed for **Rverse Analytics** — an R-focused blog covering statistics, biostatistics and reproducible workflows in R.

- Feed: https://rverseanalytics.com/blog.xml
- Site: https://rverseanalytics.com

The feed is R-only (validates as RSS 2.0; ~20 posts, all R/statistics), so it should fit the automatic weekly fetch. Thanks for the great work on R Weekly!

🤖 Generated with [Claude Code](https://claude.com/claude-code)