### PR TITLE
Add interactive gtsummary browser demos (Shiny Apps + Resources)

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -34,6 +34,8 @@ This week’s release was curated by [](), with help from the R Weekly team memb
 
 ### Resources
 
++ [Run gtsummary in your browser — an editable webR demo](https://rverseanalytics.com/gtsummary-live-demo)
+
 
 
 ### New Packages
@@ -67,6 +69,8 @@ This week’s release was curated by [](), with help from the R Weekly team memb
 
 
 ### Shiny Apps
+
++ [Interactive Table 1 explorer with gtsummary, running in the browser via Shinylive](https://rverseanalytics.com/demos)
 
 
 


### PR DESCRIPTION
Two free, browser-based demos for building a clinical "Table 1" with **gtsummary**, on the dataset that ships with the package — nothing installed, all client-side via WebAssembly. Placed in the sections that fit, but please reshuffle as needed:

- **Shiny Apps** — a point-and-click Table 1 explorer (Shinylive): https://rverseanalytics.com/demos
- **Resources** — an editable-code gtsummary demo (webR / quarto-live): https://rverseanalytics.com/gtsummary-live-demo

R code is visible/editable in both. Thanks!

🤖 Generated with [Claude Code](https://claude.com/claude-code)