### PR TITLE
Added new RSS feed for qol_blog

### DIFF
--- a/rss_feeds.csv
+++ b/rss_feeds.csv
@@ -459,3 +459,4 @@
 "https://github.com/BenWiseman/roperators/releases.atom",1,""
 "https://bastianolea.rbind.io/blog/index.xml",1,""
 "https://jolars.co/blog/index-r.xml",1,"https://bsky.app/profile/jolars.co"
+"https://s3rdia.github.io/qol_blog/index.xml", 1, ""


### PR DESCRIPTION
I added my rss feed to the csv file. There is only R content on the blog, until now mainly about the development of my package.
