### PR TITLE
Add californiaalw to New Packages

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -54,6 +54,8 @@ This week’s release was curated by [](), with help from the R Weekly team memb
 
 **GitHub or Bitbucket or GitLab**
 
++ [{californiaalw}](https://github.com/asafichaki/californiaalw): California Assisted Living Waiver facility records and county aggregates prepared from California DHCS data
+
 
 
 ### Updated Packages


### PR DESCRIPTION
Adds the new californiaalw package to the GitHub packages section. Version 0.1.0 was released on July 18, 2026, and its public R CMD check passes with zero errors and zero warnings. The package provides tested access to California Assisted Living Waiver facility records and county aggregates prepared from official California DHCS data.