### PR TITLE
Add ihsMW to Updated Packages (CRAN)

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -60,6 +60,8 @@ This week’s release was curated by [](), with help from the R Weekly team memb
 
 <i>🔍 [Search on R-universe](https://r-universe.dev/search/) 🔍</i>
 
++ [{ihsMW} 1.1.1](https://cran.r-project.org/package=ihsMW): Clean and Harmonise 'Malawi Integrated Household Survey' Data - [diffify](https://diffify.com/R/ihsMW)
+
 ### Videos and Podcasts
 
 + [Listen to the R-Weekly Highlights Podcast](https://serve.podhome.fm/r-weekly-highlights)


### PR DESCRIPTION
Adds ihsMW 1.1.1 (published to CRAN 2026-07-29) under Updated Packages; it is listed there rather than New Packages because the package first appeared on CRAN on 2026-05-04.