### PR TITLE
Fix incorrect github-lingustist stat.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+json/* linguist-documentation


### PR DESCRIPTION
the directory *json* contains a lot of .r (small case) files; they are technically json files. But they are counted as written in `Rez`.
