### PR TITLE
Add uvr and {uvr} for W34

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -37,6 +37,7 @@ This week’s release was curated by [](), with help from the R Weekly team memb
 
 ### Resources
 
++ [uvr](https://github.com/nbafrank/uvr): A uv-style package and project manager for R, written in Rust. One tool for the R version, a manifest and lockfile, and a per-project isolated library, installing from pre-built P3M binaries. Scripts can also declare dependencies in an inline header and run standalone with no project — the R analogue of PEP 723. Usable from R via a companion package.
 
 
 ### New Packages
@@ -54,6 +55,7 @@ This week’s release was curated by [](), with help from the R Weekly team memb
 
 **GitHub or Bitbucket or GitLab**
 
++ [{uvr}](https://github.com/nbafrank/uvr-r): R interface to [uvr](https://github.com/nbafrank/uvr) — manage R versions, lockfiles and isolated project libraries from the R console, RStudio or Positron without dropping to a terminal.
 
 
 ### Updated Packages


### PR DESCRIPTION
Two related entries for W34.

**Resources** — [uvr](https://github.com/nbafrank/uvr), a package and project manager for R written in Rust: one tool for the R version, a manifest and lockfile, and a per-project isolated library, installing from pre-built P3M binaries. The newest release adds inline script headers, so an `.R` file can declare its own dependencies and run with no project at all — the R analogue of PEP 723.

**New Packages → GitHub** — [{uvr}](https://github.com/nbafrank/uvr-r), the R companion package, for driving all of that from the R console, RStudio or Positron rather than a terminal.

I've listed them separately because they're genuinely different artifacts and land in different sections, but if you'd rather carry just one, the Resources entry is the more useful of the two — happy for you to drop the other.

Disclosure: I'm the author of both.
