### PR TITLE
Add dual CLI tool

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -54,6 +54,8 @@ This week’s release was curated by [](), with help from the R Weekly team memb
 
 **GitHub or Bitbucket or GitLab**
 
++ [dual: A cross-platform project manager for R and Python](https://github.com/JustSplash8501/dual) - Manage runtimes, dependencies, lockfiles, and reproducible tasks for R, Python, or mixed-language scientific projects.
+
 
 
 ### Updated Packages


### PR DESCRIPTION
## Summary

- Add `dual`, a cross-platform CLI tool for reproducible R and Python projects, to the GitHub tools subsection of the current R Weekly draft.
- Describe it as a project manager and CLI tool rather than an R package.

## Why

Dual manages runtimes, dependencies, lockfiles, and reproducible tasks for R, Python, and mixed-language scientific projects. This places it under the contribution guide's "New Packages and Tools" category.

## Validation

- Confirmed the entry is in the current 2026-W34 draft.
- Confirmed the Markdown diff passes `git diff --check`.
- Used an HTTPS link to the public project repository.
