### PR TITLE
Add permittimelines to New Packages

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -54,6 +54,8 @@ This week’s release was curated by [](), with help from the R Weekly team memb
 
 **GitHub or Bitbucket or GitLab**
 
++ [{permittimelines}](https://github.com/asafichaki/permittimelines): Garage-conversion and ADU building-permit timeline data for Los Angeles, San Diego, San Francisco, and Seattle, prepared from each city's official open-data portal
+
 
 
 ### Updated Packages


### PR DESCRIPTION
Adds the new permittimelines package to the GitHub packages section. Version 0.1.0 was released on August 24, 2026, and its public R CMD check passes with zero errors and zero warnings. The package provides tested access to residential garage-conversion and ADU building-permit timeline records for Los Angeles, San Diego, San Francisco, and Seattle, prepared from each city's official open-data portal.