### PR TITLE
Add jsslintr blog post to Insights

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -18,6 +18,7 @@ This week’s release was curated by [](), with help from the R Weekly team memb
 
 ### Insights
 
++ [jsslintr: check JSS manuscript style from R (and everywhere else)](https://kollerma.github.io/jss-style-checker/blog/)
 
 
 ### R in the Real World


### PR DESCRIPTION
Adds one link to Insights: an announcement/overview post for jsslintr (CRAN), a style checker for Journal of Statistical Software manuscripts — what it checks, how its precision/recall are measured, and its other channels (CLI/Python/VS Code/browser).

Disclosure: I am the package author, and the post is on the project's own blog.