### PR TITLE
Add rewind to Insights and New Packages

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -18,6 +18,7 @@ This week’s release was curated by [](), with help from the R Weekly team memb
 
 ### Insights
 
++ [Undo for Shiny, and the three problems that make it interesting](https://tenmeh.github.io/posts/2026-08-27-undo-for-shiny/)
 
 
 ### R in the Real World
@@ -47,6 +48,7 @@ This week’s release was curated by [](), with help from the R Weekly team memb
 
 **CRAN**
 
++ [{rewind} 0.2.0](https://cran.r-project.org/package=rewind): Undo and Redo for 'Shiny' Applications
 
 **Bioconductor**
 


### PR DESCRIPTION
Two entries.

**Insights** - a post on the design problems behind adding undo to Shiny: restoring a widget the package has never seen by going through the input binding, stopping the echo a restore sends back, and a bug caused by R's lazy argument evaluation silently removing an observer's reactive dependencies.

**New Packages / CRAN** - {rewind} 0.2.0, which went to CRAN on 20 August.

Thanks for R Weekly.