### PR TITLE
Add ggstratify to New Packages

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -47,6 +47,7 @@ This week’s release was curated by [](), with help from the R Weekly team memb
 
 **CRAN**
 
++ [{ggstratify} 0.0.1](https://cran.r-project.org/package=ggstratify): Fast Stratified Descriptive Figures with a Point-and-Click GUI
 
 **Bioconductor**
 


### PR DESCRIPTION
`ggstratify` reached CRAN on 2026-09-02, which falls in this week.

+ [{ggstratify} 0.0.1](https://cran.r-project.org/package=ggstratify): Fast Stratified Descriptive Figures with a Point-and-Click GUI

It is a one-function Shiny interface for the descriptive analysis that comes before a model is chosen: pick the variable to describe, add the variables to see it within, and every stratum is reported with the number of observations behind it, with the `ggplot2` code for the figure printed on screen. It runs locally, with no network access.

Docs: https://akishiroshita.github.io/ggstratify/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4ySN7SYwGbjszXceUteaH