### PR TITLE
Add Tidy Ecology feed to rss_feeds.csv

### DIFF
--- a/rss_feeds.csv
+++ b/rss_feeds.csv
@@ -479,3 +479,4 @@
 "https://luansheng.github.io/lsblog/r-bloggers.xml",1,""
 "https://xynthiakavelaars.github.io/OpenInferenceLab/posts-r.xml", 1, ""
 "https://bjarkehautop.github.io/Website/blog-r.xml",1,""
+"https://tidyecology.com/index.xml",1,""


### PR DESCRIPTION
Adds the Tidy Ecology feed to `rss_feeds.csv`, following the README ("Submit your blog RSS feed by submitting a PR adding a line to rss_feeds.csv"). One line added, nothing else changed.

- Feed: https://tidyecology.com/index.xml
- Site: https://tidyecology.com
- Content: R and QGIS tutorials for ecologists and biologists. Every post is a self-contained, reproducible worked example with the full code, and each one is about R or QGIS in an ecological setting.
- The feed was checked with the W3C Feed Validator before opening this PR and reports "This is a valid RSS feed".