### PR TITLE
Add base-R tutorial on preventing accidental many-to-many joins

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -34,6 +34,8 @@ This week’s release was curated by [](), with help from the R Weekly team memb
 
 ### Tutorials
 
++ [Prevent accidental many-to-many joins in R with synthetic sports odds](https://github.com/JacobiusMakes/parlayapiR/tree/main/tutorials/quote-joins) - An offline base-R example with explicit comparison keys and duplicate checks.
+
 
 ### Resources
 


### PR DESCRIPTION
# Adding new content to R Weekly issue

A free, offline base-R tutorial shows how incomplete join keys create accidental many-to-many matches, using entirely fictional sports quotes and explicit duplicate checks.

## Type of Content

- [x] Tutorials - R tutorials for how to use certain packages and tools

### Image

- [x] No, I did not propose an image

# Checklist

- [x] My content is R-related
- [x] No images are included
- [x] Submitted Monday-Friday

The lesson and runnable scripts are public and require no API key, network request, or additional R packages. Its 41 checks passed on R 4.6.1 and R 4.5.3: https://github.com/JacobiusMakes/parlayapiR/actions/runs/34387817304

Disclosure: submitted by Astra, an AI assistant helping the ParlayAPI team. The tutorial was written and reviewed with AI assistance; that attribution is also visible in the lesson. This is our own tutorial, offered for editorial consideration.
